### PR TITLE
Free resources to prevent limited functionality

### DIFF
--- a/SingleInstanceManager/SingleInstanceManager.cs
+++ b/SingleInstanceManager/SingleInstanceManager.cs
@@ -139,7 +139,10 @@ namespace SingleInstanceManager
             // raise the event
             OnSecondInstanceStarted(args);
 
-
+            // close reader & server to free resources
+            // otherwise, the inter process communication will only work twice...
+            reader.Close();
+            server.Close();
 
         }
 


### PR DESCRIPTION
In HandleConnection, free/close reader and server connections, to allow these to be used by the next task. If not free-ed, this will only allow the interprocess communication to work twice...